### PR TITLE
Fix problem with method 'refreshAccessToken'. 

### DIFF
--- a/lib/meli.js
+++ b/lib/meli.js
@@ -22,6 +22,18 @@ var needle = require('needle');
 var config = require('../config.js').config;
 var Meli = function (client_id, client_secret, access_token, refresh_token) {
 
+
+   /**
+     * Save the parameters in a private variable
+     */
+    var _parameters = {
+        client_id: client_id,
+        client_secret: client_secret,
+        access_token: access_token,
+        refresh_token: refresh_token
+    };
+
+
     /**
      *
      * get the auth url.
@@ -34,8 +46,8 @@ var Meli = function (client_id, client_secret, access_token, refresh_token) {
 
         var query = {
             response_type: 'code',
-            client_id: client_id,
-            redirect_uri: redirect_uri
+            client_id: _parameters.client_id,
+            redirect_uri: _parameters.redirect_uri
         };
         return config.auth_url + convertObjectToQueryString(query);
 
@@ -54,16 +66,16 @@ var Meli = function (client_id, client_secret, access_token, refresh_token) {
         var self = this;
         needle.post(config.oauth_url, {
             grant_type: 'authorization_code',
-            client_id: client_id,
-            client_secret: client_secret,
+            client_id: _parameters.client_id,
+            client_secret: _parameters.client_secret,
             code: code,
-            redirect_uri: redirect_uri
+            redirect_uri: _parameters.redirect_uri
         }, {
         }, function (err, res, body) {
             if (body) {
-                self.access_token = body.access_token;
-                self.refresh_token = body.refresh_token;
-                self.redirect_uri = redirect_uri;
+                _parameters.access_token = body.access_token;
+                _parameters.refresh_token = body.refresh_token;
+                _parameters.redirect_uri = redirect_uri;
             }
             callback(err, body);
         });
@@ -78,14 +90,14 @@ var Meli = function (client_id, client_secret, access_token, refresh_token) {
         var self = this;
         needle.post(config.oauth_url, {
             grant_type: 'refresh_token',
-            client_id: client_id,
-            client_secret: client_secret,
-            refresh_token: refresh_token
+            client_id: _parameters.client_id,
+            client_secret: _parameters.client_secret,
+            refresh_token: _parameters.refresh_token
         }, {
         }, function (err, res, body) {
             if (body) {
-                self.refresh_token = body.refresh_token;
-                self.access_token = body.access_token;
+                _parameters.refresh_token = body.refresh_token;
+                _parameters.access_token = body.access_token;
             }
             callback(err, body);
         });
@@ -237,8 +249,10 @@ var Meli = function (client_id, client_secret, access_token, refresh_token) {
      * @returns {string}
      */
     var convertObjectToQueryString = function (obj) {
-        if (!obj.access_token && access_token)
-            obj.access_token = access_token;
+        // Clone the object obj and loose the reference
+        obj = Object.create(obj);
+        if (!obj.access_token && _parameters.access_token)
+            obj.access_token = _parameters.access_token;
         var result = '?';
         for (var i in obj) {
             result += i + "=";


### PR DESCRIPTION
Before this fix, if the method 'refreshAccessToken' was called, all the request still used the old access_token. This change adds all the parameters inside a global private variable so it's consistent during all the flow. 